### PR TITLE
Run apt update and apt install together

### DIFF
--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -1,9 +1,8 @@
 FROM debian:buster-slim
 LABEL maintainer="Mingwei Zhang <mingwei@caida.org>"
 
-RUN apt update 
-
-RUN apt install -y python2.7-minimal python3.7-minimal curl lsb-release sudo
+RUN apt update && \
+    apt install -y python2.7-minimal python3.7-minimal curl lsb-release sudo
 
 RUN curl https://pkg.caida.org/os/debian/bootstrap.sh | bash
 

--- a/Dockerfile.unstable
+++ b/Dockerfile.unstable
@@ -1,9 +1,8 @@
 FROM debian:buster-slim
 LABEL maintainer="Mingwei Zhang <mingwei@caida.org>"
 
-RUN apt update 
-
-RUN apt install -y python2.7-minimal python3.7-minimal curl lsb-release sudo
+RUN apt update && \
+  apt install -y python2.7-minimal python3.7-minimal curl lsb-release sudo
 
 RUN curl https://pkg.caida.org/os/debian/bootstrap-unstable.sh | bash
 


### PR DESCRIPTION
If we run them separately, docker can cache the result of running `apt
update` and then fail to install packages that have changed.

See https://stackoverflow.com/questions/37706635/in-docker-apt-get-install-fails-with-failed-to-fetch-http-archive-ubuntu-com